### PR TITLE
Recognize declined transactions from OK responses

### DIFF
--- a/connexpay/src/Web/Connexpay/Payments.hs
+++ b/connexpay/src/Web/Connexpay/Payments.hs
@@ -5,6 +5,7 @@ module Web.Connexpay.Payments
   , ExpirationDate(..)
   , Customer(..)
   , RiskData(..)
+  , AuthorizeResult(..)
   , AuthResponse(..)
   , TransactionStatus(..)
   , authorisePayment
@@ -26,12 +27,13 @@ import Web.Connexpay.Types
 
 -- | Authorise a credit card payment.
 authorisePayment
-  :: Connexpay -> Env -> AuthRequest -> IO (Response AuthError AuthResponse)
-authorisePayment connexpay env raw = guessResponseErrorType guessAuthError <$>
-  doRequest connexpay env "authonlys" RequestBody
-    { raw
-    , logMasker = maskAuthRequest
-    }
+  :: Connexpay -> Env -> AuthRequest -> IO (Response AuthError AuthorizeResult)
+authorisePayment connexpay env raw =
+  bimapResponse (guessErrorType guessAuthError) postProcessAuthResponse <$>
+    doRequest connexpay env "authonlys" RequestBody
+      { raw
+      , logMasker = maskAuthRequest
+      }
 
 -- | Void payment
 voidPayment :: Connexpay -> Env -> VoidRequest -> IO (Response () ())

--- a/connexpay/src/Web/Connexpay/Types.hs
+++ b/connexpay/src/Web/Connexpay/Types.hs
@@ -67,8 +67,8 @@ bimapResponse f g = \case
   BadRequest body -> BadRequest body
   MissingOrExpiredToken -> MissingOrExpiredToken
 
-guessResponseErrorType :: (Error () -> e) -> Response () a -> Response e a
-guessResponseErrorType mkErr = bimapResponse (\e -> e { errorType = mkErr e }) id
+guessErrorType :: (Error () -> e) -> Error () -> Error e
+guessErrorType mkErr e = e { errorType = mkErr e }
 
 data Error e = Error
   { message :: Text


### PR DESCRIPTION
Not necessarily 2XX OK from Connexpay indicates that transaction is approved. We need to look at the response to verify that.